### PR TITLE
Moved classnames package from devDependencies to dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "react-redux": "^7.2.2",
     "react-test-renderer": "^17.0.2",
     "redux": "^4.0.5",
-    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.1"
+    "tailwindcss": "npm:@tailwindcss/postcss7-compat@^2.0.1",
+    "classnames": "^2.3.1"
   },
   "husky": {
     "hooks": {
@@ -55,7 +56,6 @@
     "babel-eslint": "^10.1.0",
     "babel-jest": "^26.6.3",
     "babel-plugin-inline-react-svg": "^2.0.1",
-    "classnames": "^2.3.1",
     "eslint": "^7.18.0",
     "eslint-config-airbnb": "^18.2.1",
     "eslint-config-airbnb-typescript": "^12.3.1",


### PR DESCRIPTION
The linter complains about the package classnames being in dependencies instead of devDependencies.