### PR TITLE
Fix storybook issue

### DIFF
--- a/.storybook/main.js
+++ b/.storybook/main.js
@@ -8,4 +8,5 @@ module.exports = {
     '@storybook/addon-essentials',
     'storybook-css-modules-preset',
   ],
+  typescript: { reactDocgen: 'react-docgen' },
 };


### PR DESCRIPTION
I found that issue #145 is related to performance issues in ``storybook`` which can cause a memory leak sometimes. and I solved it when I configure the following setting in ``.storybook/main.js``
``` javascript
module.exports = {
  typescript: { reactDocgen: 'react-docgen' }
}
```
The main reason that  ``react-docgen-typescript`` which shown on the issue above is slower than ``react-docgen`` at the way each library gets the ``types`` information.

