### PR TITLE
Get now date

### DIFF
--- a/modules/shared/components/organisms/MiniSurveyView/MiniSurveyView.test.tsx
+++ b/modules/shared/components/organisms/MiniSurveyView/MiniSurveyView.test.tsx
@@ -3,11 +3,13 @@ import * as renderer from 'react-test-renderer';
 import type { IPostFeed } from '../../../types/postFeed/IPostFeed';
 import MiniSurveyView from './MiniSurveyView';
 
+jest.mock('../../../logic/formatDate/getNow');
+
 describe('ITextPollView', () => {
   const mockedPost: IPostFeed.IPost = {
     caption: 'nalyzing Delaware Frozen',
     id: '03644270-7171-4147-b5a1-4233ff547f7ddda',
-    created_at: '2021-05-24T23:10:24.114Z',
+    created_at: '2020-12-31T00:00:00.000Z',
     user: {
       name: 'Ahmed Ayoub',
       id: '465456',

--- a/modules/shared/components/organisms/MiniSurveyView/__snapshots__/MiniSurveyView.test.tsx.snap
+++ b/modules/shared/components/organisms/MiniSurveyView/__snapshots__/MiniSurveyView.test.tsx.snap
@@ -93,9 +93,9 @@ exports[`ITextPollView should render ITextPollView Compnent with the mocked data
           </span>
           <span
             className="date"
-            title="25/05/2021 01:10:24"
+            title="31/12/2020 02:00:00"
           >
-            24 days ago
+            a day ago
           </span>
         </div>
       </div>

--- a/modules/shared/components/organisms/TextPollView/TextPollView.test.tsx
+++ b/modules/shared/components/organisms/TextPollView/TextPollView.test.tsx
@@ -3,11 +3,13 @@ import * as renderer from 'react-test-renderer';
 import TextPollView from './TextPollView';
 import type { IPostFeed } from '../../../types/postFeed/IPostFeed';
 
+jest.mock('../../../logic/formatDate/getNow');
+
 describe('ITextPollView', () => {
   const mockedPost: IPostFeed.IPost = {
     caption: 'nalyzing Delaware Frozen',
     id: '03644270-7171-4147-b5a1-4233ff547f7ddda',
-    created_at: '2021-05-24T23:10:24.114Z',
+    created_at: '2020-12-31T00:00:00.000Z',
     user: {
       name: 'Ahmed Ayoub',
       id: '465456',

--- a/modules/shared/components/organisms/TextPollView/__snapshots__/TextPollView.test.tsx.snap
+++ b/modules/shared/components/organisms/TextPollView/__snapshots__/TextPollView.test.tsx.snap
@@ -93,9 +93,9 @@ exports[`ITextPollView should render ITextPollView Compnent with the mocked data
           </span>
           <span
             className="date"
-            title="25/05/2021 01:10:24"
+            title="31/12/2020 02:00:00"
           >
-            23 days ago
+            a day ago
           </span>
         </div>
       </div>

--- a/modules/shared/logic/formatDate/FormatDate.ts
+++ b/modules/shared/logic/formatDate/FormatDate.ts
@@ -1,10 +1,11 @@
 import dayjs from 'dayjs';
 import relativeTime from 'dayjs/plugin/relativeTime';
+import { getNow } from './getNow';
 
 dayjs.extend(relativeTime);
 
 export const humanReadableDate = (date: Date): string => {
-  return dayjs(date).fromNow();
+  return dayjs(date).from(getNow());
 };
 
 export const exactDate = (date: Date): string => {

--- a/modules/shared/logic/formatDate/__mocks__/getNow.ts
+++ b/modules/shared/logic/formatDate/__mocks__/getNow.ts
@@ -1,0 +1,5 @@
+import dayjs from 'dayjs';
+
+export const getNow = (): dayjs.Dayjs => {
+  return dayjs('2021-01-01T00:00:00.000Z');
+};

--- a/modules/shared/logic/formatDate/getNow.ts
+++ b/modules/shared/logic/formatDate/getNow.ts
@@ -1,0 +1,5 @@
+import dayjs from 'dayjs';
+
+export const getNow = (): dayjs.Dayjs => {
+  return dayjs();
+};


### PR DESCRIPTION
this PR will fix the date & time snapshot testing by mocking the getNow function using jest mock, that allows us to mock the current date and time in the testing