### PR TITLE
Fix time zone issue at the snapshot testing

### DIFF
--- a/modules/shared/components/organisms/MiniSurveyView/MiniSurveyView.test.tsx
+++ b/modules/shared/components/organisms/MiniSurveyView/MiniSurveyView.test.tsx
@@ -9,7 +9,7 @@ describe('ITextPollView', () => {
   const mockedPost: IPostFeed.IPost = {
     caption: 'nalyzing Delaware Frozen',
     id: '03644270-7171-4147-b5a1-4233ff547f7ddda',
-    created_at: '2020-12-31T00:00:00.000Z',
+    created_at: '2020-12-31T00:00:00.000',
     user: {
       name: 'Ahmed Ayoub',
       id: '465456',

--- a/modules/shared/components/organisms/MiniSurveyView/__snapshots__/MiniSurveyView.test.tsx.snap
+++ b/modules/shared/components/organisms/MiniSurveyView/__snapshots__/MiniSurveyView.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`ITextPollView should render ITextPollView Compnent with the mocked data
           </span>
           <span
             className="date"
-            title="31/12/2020 02:00:00"
+            title="31/12/2020 00:00:00"
           >
             a day ago
           </span>

--- a/modules/shared/components/organisms/TextPollView/TextPollView.test.tsx
+++ b/modules/shared/components/organisms/TextPollView/TextPollView.test.tsx
@@ -9,7 +9,7 @@ describe('ITextPollView', () => {
   const mockedPost: IPostFeed.IPost = {
     caption: 'nalyzing Delaware Frozen',
     id: '03644270-7171-4147-b5a1-4233ff547f7ddda',
-    created_at: '2020-12-31T00:00:00.000Z',
+    created_at: '2020-12-31T00:00:00.000',
     user: {
       name: 'Ahmed Ayoub',
       id: '465456',

--- a/modules/shared/components/organisms/TextPollView/__snapshots__/TextPollView.test.tsx.snap
+++ b/modules/shared/components/organisms/TextPollView/__snapshots__/TextPollView.test.tsx.snap
@@ -93,7 +93,7 @@ exports[`ITextPollView should render ITextPollView Compnent with the mocked data
           </span>
           <span
             className="date"
-            title="31/12/2020 02:00:00"
+            title="31/12/2020 00:00:00"
           >
             a day ago
           </span>


### PR DESCRIPTION
A new issue appeared after merging the last PR according to the time zone difference between the machines that run the tests.
![image](https://user-images.githubusercontent.com/52051312/122965472-824c8d00-d388-11eb-8872-9bebab2a3c6a.png)
```02:00:00``` according to the local machine time zone it adds 2 hours ``GMT+2`` aka ``Greenwich Mean Time + 2 hours`` according to ``Eastern European Standard Time`` but it should match the timezone that runs these tests in GitHub or any other machine  ```00:00:00``` 