### PR TITLE
added a custom hook to detect click outside

### DIFF
--- a/modules/shared/hooks/useDetectClickOut/IUseDetectClickOut.d.ts
+++ b/modules/shared/hooks/useDetectClickOut/IUseDetectClickOut.d.ts
@@ -1,0 +1,12 @@
+import type { MutableRefObject } from 'react';
+
+declare namespace IUseDetectClickOut {
+  export interface IDetextClickOut {
+    triggerRef: MutableRefObject<HTMLDivElement | null>;
+    show: boolean;
+    setShow: (initState: boolean) => void;
+    nodeRef: MutableRefObject<HTMLDivElement | null>;
+  }
+}
+
+export { IUseDetectClickOut };

--- a/modules/shared/hooks/useDetectClickOut/useDetectClickOut.ts
+++ b/modules/shared/hooks/useDetectClickOut/useDetectClickOut.ts
@@ -1,0 +1,34 @@
+import { useEffect, useState, useRef } from 'react';
+import type { IUseDetectClickOut } from './IUseDetectClickOut';
+
+export const useDetectClickOut = (
+  initState: boolean,
+): IUseDetectClickOut.IDetextClickOut => {
+  const [show, setShow] = useState(initState);
+  const nodeRef = useRef<HTMLDivElement | null>(null);
+  const triggerRef = useRef<HTMLDivElement | null>(null);
+
+  const handleClickOutside = (e: MouseEvent): void => {
+    if (triggerRef.current?.contains(e.target as Node)) {
+      setShow(!show);
+      return;
+    }
+
+    if (!nodeRef.current?.contains(e.target as Node)) {
+      setShow(false);
+    }
+  };
+  useEffect(() => {
+    document.addEventListener('click', handleClickOutside, true);
+    return (): void => {
+      document.removeEventListener('click', handleClickOutside, true);
+    };
+  });
+
+  return {
+    triggerRef,
+    show,
+    setShow,
+    nodeRef,
+  };
+};


### PR DESCRIPTION
By using this hook you can 
- detect clicking outside the component or specific element
- toggle the state to show and close the **dropDown** menu for example