### PR TITLE
make post button disable while creating post request

### DIFF
--- a/modules/HomePage/components/NewPost/NewPost.tsx
+++ b/modules/HomePage/components/NewPost/NewPost.tsx
@@ -11,6 +11,8 @@ import initialState from '../../../shared/components/organisms/PostCreation/post
 import type { IPostCreation } from '../../../shared/components/organisms/PostCreation/types/IPostCreation';
 
 const NewPost = (): ReactElement => {
+  const [creating, setCreating] = useState<boolean>(false);
+
   const [postCreationGlobalState, setPostCreationGlobalState] =
     useState<IPostCreation.IState>(initialState);
 
@@ -64,6 +66,8 @@ const NewPost = (): ReactElement => {
             postCreationGlobalState={postCreationGlobalState}
             setPostCreationGlobalState={setPostCreationGlobalState}
             useFormConfig={useFormConfig}
+            creating={creating}
+            setCreating={setCreating}
           />
         </Modal>
       )}

--- a/modules/shared/components/organisms/PostCreation/PostCreation.tsx
+++ b/modules/shared/components/organisms/PostCreation/PostCreation.tsx
@@ -28,10 +28,11 @@ const PostCreation: FC<IPostCreation.IProps> = ({
   postCreationGlobalState,
   setPostCreationGlobalState,
   useFormConfig,
+  creating,
+  setCreating,
 }): ReactElement => {
   const zero = 0;
   // post creation global initial state setup
-  const [creating, setCreating] = useState<boolean>(false);
 
   const [mediaCount, setMediaCount] = useState<{
     imagePoll: number;

--- a/modules/shared/components/organisms/PostCreation/types/IPostCreation.d.ts
+++ b/modules/shared/components/organisms/PostCreation/types/IPostCreation.d.ts
@@ -7,6 +7,8 @@ declare namespace IPostCreation {
     postCreationGlobalState: IState;
     setPostCreationGlobalState: (state: IState) => void;
     useFormConfig: UseFormReturn;
+    creating: boolean;
+    setCreating: React.Dispatch<React.SetStateAction<boolean>>;
   }
   export interface IPostStructure {
     postType: EPollType.ImagePoll | EPollType.MiniSurvey | EPollType.TextPoll;


### PR DESCRIPTION
- make the post button and its functionality disabled to prevent the user from creating multiple posts requests at the same time