### PR TITLE
make File Uploader for Mini Survey accepts only one image

### DIFF
--- a/modules/shared/components/atoms/FileUploader/FileUploader.tsx
+++ b/modules/shared/components/atoms/FileUploader/FileUploader.tsx
@@ -98,7 +98,9 @@ const FileUploader: FC<IFileUploader.IProps> = ({
         })
         .join(', and ');
     }
-    return 'Upload one or multiple files';
+    return entityType === 'post'
+      ? 'Attach an image'
+      : 'Upload one or multiple images';
   };
 
   return (
@@ -125,7 +127,11 @@ const FileUploader: FC<IFileUploader.IProps> = ({
         <span>
           <Image className={svgClasses} />
         </span>
-        <p className={textClasses}>Upload one or multiple images</p>
+        <p className={textClasses}>
+          {entityType === 'post'
+            ? 'Attach an image'
+            : 'Upload one or multiple images'}
+        </p>
       </label>
     </div>
   );

--- a/modules/shared/components/organisms/MiniSurveyPollCreation/MiniSurveyPollCreation.tsx
+++ b/modules/shared/components/organisms/MiniSurveyPollCreation/MiniSurveyPollCreation.tsx
@@ -286,7 +286,7 @@ const MiniSurveyPollCreation: FC<IMiniSurveyPollCreation.IPorps> = ({
         {post.media.length < one && (
           <FileUploader
             onFileSuccess={onUploadValidImages}
-            maxFiles={configPostCreation.maxUploadedFiles}
+            maxFiles={configPostCreation.maxUploadFilesMiniSurvey}
             entityType="post"
             lastFilesLength={post.media.length}
           />

--- a/modules/shared/configuration/ConfigPostCreation/config.ts
+++ b/modules/shared/configuration/ConfigPostCreation/config.ts
@@ -1,6 +1,7 @@
 /* eslint-disable */
 export enum configPostCreation {
   maxUploadedFiles = 4,
+  maxUploadFilesMiniSurvey = 1,
   maxFileSizeInByte = 10000000, // 10MB
   maxFileSizeInMegaByte = maxFileSizeInByte / 1000000,
   maxOptionGroup = 4,


### PR DESCRIPTION
solves #306 
- Changed the label and input title of the File Uploader to one image for the miniSurvey creation and to one or multiple for textpoll creation.
- The file uploader for miniSurvey creation accepts only one image.