### PR TITLE
Enhance mini survey

### DIFF
--- a/modules/shared/components/molecules/OptionGroupWrapper/OptionGroupsHeader/OptionGroupHeader.test.tsx
+++ b/modules/shared/components/molecules/OptionGroupWrapper/OptionGroupsHeader/OptionGroupHeader.test.tsx
@@ -78,7 +78,7 @@ describe('OptionGroupHeader', () => {
     render(
       <OptionGroupsHeader
         id={miniSurveyState.groups[zero].id}
-        index={1}
+        index={2}
         optionGroupName={miniSurveyState.groups[zero].name}
         deleteOptionsGroupHandler={deleteGroupMockedFunction}
         updateOptionsGroupNameHandler={(): boolean => true}

--- a/modules/shared/components/molecules/OptionGroupWrapper/OptionGroupsHeader/OptionGroupHeader.tsx
+++ b/modules/shared/components/molecules/OptionGroupWrapper/OptionGroupsHeader/OptionGroupHeader.tsx
@@ -12,7 +12,6 @@ const OptionGroupsHeader: FC<IOptionGroupHeader.IProps> = ({
   updateOptionsGroupNameHandler,
   deleteOptionsGroupHandler,
 }): ReactElement => {
-  const zero = 0;
   const [groupName, setGroupName] = useState<string>(
     optionGroupName || `Group ${index}`,
   );
@@ -38,7 +37,7 @@ const OptionGroupsHeader: FC<IOptionGroupHeader.IProps> = ({
             }}
           />
           <div className="flex">
-            {index !== zero && (
+            {index > 1 && (
               <button
                 data-testid="removeGroupButton"
                 type="button"


### PR DESCRIPTION
- To prevent the user from creating a mini Survey poll without any groups we need to make at least one group required always