### PR TITLE
persist the post footer layout

### DIFF
--- a/modules/shared/components/molecules/postFooter/PostFooter.tsx
+++ b/modules/shared/components/molecules/postFooter/PostFooter.tsx
@@ -16,7 +16,9 @@ const PostFooter: FC<IPostFooter.IProps> = ({
       {!showResult && <span> Vote to uncover the total number of voters </span>}
       {showResult && <span>{numberOfVotes} votes</span>}
       {copied ? (
-        <p>Copied</p>
+        <div className="h-l">
+          <span>Copied</span>
+        </div>
       ) : (
         <button
           type="button"


### PR DESCRIPTION
solves ##373

- added fixed height to the prompt "copied" state to be the same height as the icon share button.