### PR TITLE
unoptimize next image   

### DIFF
--- a/modules/shared/components/atoms/ImageView/ImageView.tsx
+++ b/modules/shared/components/atoms/ImageView/ImageView.tsx
@@ -21,6 +21,7 @@ const ImageView: FC<IImageView.IProps> = ({
           height={600}
           id={id}
           alt={imgAlt}
+          unoptimized
         />
       </div>
       <Image
@@ -32,6 +33,7 @@ const ImageView: FC<IImageView.IProps> = ({
         height={600}
         id={id}
         alt={imgAlt}
+        unoptimized
       />
     </div>
   );


### PR DESCRIPTION
closes #269
- add unoptimized attribute on **Image** from `next/image` to load images faster