### PR TITLE
upgrade docker cleanup action version

### DIFF
--- a/.github/workflows/m3ntorship-dev_frontend_dev.yaml
+++ b/.github/workflows/m3ntorship-dev_frontend_dev.yaml
@@ -112,7 +112,7 @@ jobs:
     steps:
       - id: delete_old_tags
         name: Delete old docker image tags
-        uses: m3ntorship/action-dockerhub-cleanup@1.2
+        uses: m3ntorship/action-dockerhub-cleanup@1.4
         with:
           token: ${{secrets.DOCKER_HUB_M3NTORSHIPCI_TOKEN}}
           keep-last: 5

--- a/.github/workflows/m3ntorship-dev_frontend_dev.yaml
+++ b/.github/workflows/m3ntorship-dev_frontend_dev.yaml
@@ -114,7 +114,8 @@ jobs:
         name: Delete old docker image tags
         uses: m3ntorship/action-dockerhub-cleanup@1.4
         with:
-          token: ${{secrets.DOCKER_HUB_M3NTORSHIPCI_TOKEN}}
+          username: ${{ secrets.M3NTORSHIP_DOCKERHUB_USERNAME }}
+          password: ${{ secrets.M3NTORSHIP_DOCKERHUB_PASSWORD }}
           keep-last: 5
           user: 'm3ntorshipci'
           repos: '["pickify-frontend"]'


### PR DESCRIPTION
Closes #362 
after fixing ordering and login issues, dockerhub cleaning action now has version 1.4 which has all the fixes. in order for the pipeline to work correctly, we have to upgrade the action version in all repos that uses it.

you can find dockerhub cleaning up action changes [here](https://github.com/m3ntorship/action-dockerhub-cleanup/compare/1.2...master)

