### PR TITLE
Feedback small screens

### DIFF
--- a/modules/shared/components/atoms/Button/Button.module.css
+++ b/modules/shared/components/atoms/Button/Button.module.css
@@ -31,6 +31,10 @@
 }
 
 /* // the size of the buttons  */
+.btn-full-width {
+  @apply text-sm font-medium w-full;
+}
+
 .btn-xlarge {
   @apply text-sm font-medium;
 }
@@ -56,6 +60,13 @@
 /* the only of it is kind  -the responsive cancel button-  */
 .btn-normal.btn-tertiary {
   @apply px-xll py-1.5;
+}
+
+.btn-full-width.btn-primary,
+.btn-full-width.btn-primary,
+.btn-full-width.btn-secondary,
+.btn-full-width.btn-tertiary {
+  @apply px-m py-1.5;
 }
 
 .btn-xlarge.btn-primary,

--- a/modules/shared/components/atoms/Button/Button.tsx
+++ b/modules/shared/components/atoms/Button/Button.tsx
@@ -29,6 +29,7 @@ const Button: FC<IButton.IProps> = ({
       [styles['btn-like']]: variant === 'like',
     },
     {
+      [styles['btn-full-width']]: size === 'fullWidth',
       [styles['btn-xlarge']]: size === 'xlarge',
       [styles['btn-large']]: size === 'large',
       [styles['btn-medium']]: size === 'medium',

--- a/modules/shared/components/atoms/Button/types/EButton.ts
+++ b/modules/shared/components/atoms/Button/types/EButton.ts
@@ -8,6 +8,7 @@ export enum buttonVariantValues {
   DELETE = 'delete',
 }
 export enum buttonSizeValues {
+  FULLWIDTH = 'fullWidth',
   XLARGE = 'xlarge',
   LARGE = 'large',
   MEDIUM = 'medium',

--- a/modules/shared/components/molecules/Navigation/Navigation.tsx
+++ b/modules/shared/components/molecules/Navigation/Navigation.tsx
@@ -23,7 +23,8 @@ import Feedback from '../../organisms/Feedback/Feedback';
 const Navigation: FC = (): ReactElement => {
   const { pathname } = useRouter();
   const { user } = useAuth();
-  const { redirectToLoginPage, redirectToProfilePage } = useRedirect();
+  const { redirectToLoginPage, redirectToProfilePage, redirectToFriendsPage } =
+    useRedirect();
   const homeNavLinks = getHomeNavLinks(pathname);
 
   const onMenuClick = async (menuId: string): Promise<void> => {
@@ -33,11 +34,14 @@ const Navigation: FC = (): ReactElement => {
           await logoutUser();
           redirectToLoginPage();
         } catch (err: unknown) {
-          toast.error('Logo out access is denied');
+          toast.error('Logging out access is denied');
         }
         break;
       case 'profile':
         redirectToProfilePage();
+        break;
+      case 'friends':
+        redirectToFriendsPage();
         break;
       default:
         toast.error('cant find your option :(');
@@ -70,13 +74,24 @@ const Navigation: FC = (): ReactElement => {
         </div>
         <div className={styles['nav-links']}>
           <ul>
-            {homeNavLinks.map((homeNavItem) => (
-              <li key={homeNavItem.name}>
-                <Link href={homeNavItem.path}>
-                  <a>{homeNavItem.content}</a>
-                </Link>
-              </li>
-            ))}
+            {homeNavLinks.map((homeNavItem) => {
+              if (homeNavItem.name === 'friends') {
+                return (
+                  <li key={homeNavItem.name} className="hidden sm:inline-block">
+                    <Link href={homeNavItem.path}>
+                      <a>{homeNavItem.content}</a>
+                    </Link>
+                  </li>
+                );
+              }
+              return (
+                <li key={homeNavItem.name}>
+                  <Link href={homeNavItem.path}>
+                    <a>{homeNavItem.content}</a>
+                  </Link>
+                </li>
+              );
+            })}
             <li className="hidden md:inline-block">
               <Divider length="16px" type={DividerType.Vertical} />
             </li>
@@ -85,13 +100,14 @@ const Navigation: FC = (): ReactElement => {
                 <HelpIcon className="fill-grey" />
               </a>
             </li>
-            <li className="hidden md:inline-block">
+            <li className="">
               <Feedback />
             </li>
             <li className={styles['nav-user']}>
               <DropDown
                 options={[
                   { id: 'profile', body: 'Profile' },
+                  { id: 'friends', body: 'Friends' },
                   { id: 'logout', body: 'Log Out' },
                 ]}
                 variant="post"

--- a/modules/shared/components/molecules/postFooter/PostFooter.module.css
+++ b/modules/shared/components/molecules/postFooter/PostFooter.module.css
@@ -1,3 +1,3 @@
 .container {
-  @apply text-grey font-normal text-sm;
+  @apply text-grey font-normal text-xs sm:text-sm;
 }

--- a/modules/shared/components/organisms/Feedback/Feedback.test.tsx
+++ b/modules/shared/components/organisms/Feedback/Feedback.test.tsx
@@ -1,6 +1,10 @@
 import * as React from 'react';
 import * as renderer from 'react-test-renderer';
-import { render, screen } from '@testing-library/react';
+import {
+  render,
+  screen,
+  waitForElementToBeRemoved,
+} from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import Feedback from './Feedback';
 
@@ -107,5 +111,22 @@ describe('Feedback', () => {
     const negativeFeedback = screen.getByTestId('negativeFeedback');
 
     expect(negativeFeedback).toBeInTheDocument();
+  });
+
+  beforeEach(() => jest.useFakeTimers());
+  afterEach(() => jest.useRealTimers());
+  it('wait for 2 sec after submission and then close the popup', async () => {
+    render(<Feedback />);
+    const openFeedback = screen.getByTestId('open-feedback');
+    userEvent.click(openFeedback);
+    const verySadEmoji = screen.getByTestId('1');
+    const submitButton = screen.getByRole('button');
+    userEvent.click(verySadEmoji);
+    userEvent.click(submitButton);
+
+    expect(setTimeout).toHaveBeenCalledTimes(1);
+    expect(setTimeout).toHaveBeenLastCalledWith(expect.any(Function), 2000);
+    const feedBackPopup = screen.queryByTestId('feedback-popup');
+    await waitForElementToBeRemoved(feedBackPopup);
   });
 });

--- a/modules/shared/components/organisms/Feedback/Feedback.tsx
+++ b/modules/shared/components/organisms/Feedback/Feedback.tsx
@@ -50,7 +50,7 @@ const Feedback: FC = (): ReactElement => {
   const [disabled, setDisabled] = useState(true);
   const [inputValue, setInputValue] = useState('');
   const [isSubmitted, setIsSubmitted] = useState(false);
-  const { nodeRef, triggerRef, show } = useDetectClickOut(false);
+  const { nodeRef, triggerRef, setShow, show } = useDetectClickOut(false);
 
   const onChangeInputValueHandler = (
     id: string,
@@ -75,11 +75,14 @@ const Feedback: FC = (): ReactElement => {
   };
 
   const handleSubmit = (e: React.FormEvent<HTMLFormElement>): void => {
-    setIsSubmitted(true);
     e.preventDefault();
+    setIsSubmitted(true);
+    setTimeout(() => {
+      setShow(false);
+    }, 2000);
   };
   return (
-    <div className="relative">
+    <div className="md:relative">
       <div
         className="cursor-pointer"
         ref={triggerRef}
@@ -146,7 +149,7 @@ const Feedback: FC = (): ReactElement => {
 
                       <div className={styles.button}>
                         <Button
-                          size={EButton.buttonSizeValues.XLARGE}
+                          size={EButton.buttonSizeValues.FULLWIDTH}
                           variant={EButton.buttonVariantValues.PRIMARY}
                           disabled={disabled}
                           buttonText="Submit"

--- a/modules/shared/components/organisms/Feedback/__snapshots__/Feedback.test.tsx.snap
+++ b/modules/shared/components/organisms/Feedback/__snapshots__/Feedback.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Feedback renders The Feedback initial state 1`] = `
 <div
-  className="relative"
+  className="md:relative"
 >
   <div
     className="cursor-pointer"

--- a/modules/shared/hooks/useRedirect/IUseRedirect.d.ts
+++ b/modules/shared/hooks/useRedirect/IUseRedirect.d.ts
@@ -4,6 +4,7 @@ declare namespace IUseRedirect {
     redirectToLoginPage: () => void;
     redirectToProfilePage: () => void;
     redirectToPostPage: (url: string) => void;
+    redirectToFriendsPage: () => void;
   }
 }
 

--- a/modules/shared/hooks/useRedirect/useRedirect.ts
+++ b/modules/shared/hooks/useRedirect/useRedirect.ts
@@ -15,10 +15,14 @@ export const useRedirect = (): IUseRedirect.IUseRedirectReturn => {
   const redirectToPostPage = (url: string): void => {
     router.push(url) as unknown as Promise<boolean>;
   };
+  const redirectToFriendsPage = (): void => {
+    router.push('/friends') as unknown as Promise<boolean>;
+  };
   return {
     redirectToHomePage,
     redirectToLoginPage,
     redirectToPostPage,
     redirectToProfilePage,
+    redirectToFriendsPage,
   };
 };


### PR DESCRIPTION
 - Adding the feedback icon to the navbar caused it to be crammed on small screens.
    * So I removed the Friends page icon on tiny small screens like iPhone 5 and added it to the dropDown menu.
  - Closing the feedback popup automatically after 2 seconds and added a test.
  - Added full-width variant size to the button component and used it.
  - In the post footer, the text is too large on tiny small screens so i handled this as well.