### PR TITLE
Reusabe tabs component

### DIFF
--- a/modules/shared/components/atoms/Tab/ITab.d.ts
+++ b/modules/shared/components/atoms/Tab/ITab.d.ts
@@ -1,4 +1,3 @@
-import type { EPostType } from '@modules/shared/types/postFeed/EPostType';
 import type { IRadio } from '../Radio/IRadio';
 
 declare namespace ITab {
@@ -8,9 +7,9 @@ declare namespace ITab {
   }
 
   export interface IData extends IRadio.IData {
-    value: EPostType;
+    value: string;
     checkedValue: string;
-    svg: JSX.Element;
+    svg?: JSX.Element;
   }
 
   export interface IHandlers {

--- a/modules/shared/components/atoms/Tab/ITab.d.ts
+++ b/modules/shared/components/atoms/Tab/ITab.d.ts
@@ -8,6 +8,7 @@ declare namespace ITab {
 
   export interface IData extends IRadio.IData {
     value: string;
+    content: string;
     checkedValue: string;
     svg?: JSX.Element;
   }

--- a/modules/shared/components/atoms/Tab/Tab.module.css
+++ b/modules/shared/components/atoms/Tab/Tab.module.css
@@ -2,7 +2,7 @@
   @apply cursor-pointer hover:bg-grey-shd6 flex items-center py-1.5 pr-3.5 pl-3 rounded-full;
 }
 .tab-checked {
-  @apply bg-transparent md:bg-white border border-grey;
+  @apply bg-transparent border border-grey;
 }
 .tab-unchecked {
   @apply bg-grey-bg;

--- a/modules/shared/components/atoms/Tab/Tab.stories.tsx
+++ b/modules/shared/components/atoms/Tab/Tab.stories.tsx
@@ -4,11 +4,20 @@ import styles from './Tab.module.css';
 import ImagePoll from '../../icons/imagePoll.svg';
 import Tab from './Tab';
 import type { ITab } from './ITab';
-import { EPostType } from '../../../types/postFeed/EPostType';
 
 export default {
   title: 'Atoms/Tab',
   component: Tab,
+  argTypes: {
+    checkedValue: {
+      options: ['image poll', 'text poll', 'mini survey'],
+      control: { type: 'select' },
+    },
+    value: {
+      options: ['image poll', 'text poll', 'mini survey'],
+      control: { type: 'select' },
+    },
+  },
 };
 
 const Template: Story<ITab.IProps> = (args): ReactElement => (
@@ -16,10 +25,11 @@ const Template: Story<ITab.IProps> = (args): ReactElement => (
 );
 export const tab = Template.bind({});
 tab.args = {
-  value: EPostType.ImagePoll,
+  value: 'image poll',
   id: 'anyid',
   svg: <ImagePoll className={styles.icon} />,
   checkedValue: 'image poll',
   disabled: false,
   onlyLabel: false,
+  content: 'Image Poll',
 };

--- a/modules/shared/components/atoms/Tab/Tab.stories.tsx
+++ b/modules/shared/components/atoms/Tab/Tab.stories.tsx
@@ -11,7 +11,9 @@ export default {
   component: Tab,
 };
 
-const Template: Story<ITab.IProps> = (args): ReactElement => <Tab {...args} />;
+const Template: Story<ITab.IProps> = (args): ReactElement => (
+  <Tab {...args}>Image Poll</Tab>
+);
 export const tab = Template.bind({});
 tab.args = {
   value: EPostType.ImagePoll,

--- a/modules/shared/components/atoms/Tab/Tab.test.tsx
+++ b/modules/shared/components/atoms/Tab/Tab.test.tsx
@@ -15,7 +15,9 @@ describe('Tab', () => {
           value="Mini survey"
           id="anyid"
           svg={<ImagePoll />}
-        />,
+        >
+          Mini survey
+        </Tab>,
       )
       .toJSON();
 
@@ -32,9 +34,10 @@ describe('Tab', () => {
           changeValHandler={changeValHandler}
           value="Mini survey"
           id="anyid"
-          svg={<ImagePoll />}
           onlyLabel
-        />,
+        >
+          Mini survey
+        </Tab>,
       )
       .toJSON();
 
@@ -53,7 +56,9 @@ describe('Tab', () => {
           id="anyid"
           svg={<ImagePoll />}
           disabled
-        />,
+        >
+          Mini survey
+        </Tab>,
       )
       .toJSON();
 
@@ -71,7 +76,9 @@ describe('Tab', () => {
           value="Image Poll"
           id="anyid"
           svg={<ImagePoll />}
-        />,
+        >
+          Image Poll
+        </Tab>,
       )
       .toJSON();
 

--- a/modules/shared/components/atoms/Tab/Tab.test.tsx
+++ b/modules/shared/components/atoms/Tab/Tab.test.tsx
@@ -15,9 +15,8 @@ describe('Tab', () => {
           value="Mini survey"
           id="anyid"
           svg={<ImagePoll />}
-        >
-          Mini survey
-        </Tab>,
+          content="Mini survey"
+        />,
       )
       .toJSON();
 
@@ -35,9 +34,8 @@ describe('Tab', () => {
           value="Mini survey"
           id="anyid"
           onlyLabel
-        >
-          Mini survey
-        </Tab>,
+          content="Mini survey"
+        />,
       )
       .toJSON();
 
@@ -56,9 +54,8 @@ describe('Tab', () => {
           id="anyid"
           svg={<ImagePoll />}
           disabled
-        >
-          Mini survey
-        </Tab>,
+          content="Mini survey"
+        />,
       )
       .toJSON();
 
@@ -76,9 +73,8 @@ describe('Tab', () => {
           value="Image Poll"
           id="anyid"
           svg={<ImagePoll />}
-        >
-          Image Poll
-        </Tab>,
+          content="Image Poll"
+        />,
       )
       .toJSON();
 

--- a/modules/shared/components/atoms/Tab/Tab.tsx
+++ b/modules/shared/components/atoms/Tab/Tab.tsx
@@ -14,6 +14,7 @@ const Tab: FC<ITab.IProps> = (props): ReactElement => {
     changeValHandler,
     disabled,
     onlyLabel,
+    children,
   } = props;
 
   const tabClasses: string = classNames(styles['tab-default'], {
@@ -21,16 +22,6 @@ const Tab: FC<ITab.IProps> = (props): ReactElement => {
     [styles['tab-unchecked']]: value !== checkedValue,
     [styles['tab-disabled']]: disabled,
   });
-
-  let content = 'Image Poll';
-
-  if (value === 'image poll') {
-    content = 'Image Poll';
-  } else if (value === 'text poll') {
-    content = 'Text Poll';
-  } else {
-    content = 'Mini survey';
-  }
 
   return (
     <div className="flex">
@@ -51,7 +42,7 @@ const Tab: FC<ITab.IProps> = (props): ReactElement => {
           onlyLabel={onlyLabel}
         />
         {!onlyLabel && svg}
-        <span className={styles['tab-type']}>{content}</span>
+        <span className={styles['tab-type']}>{children}</span>
       </label>
     </div>
   );

--- a/modules/shared/components/atoms/Tab/Tab.tsx
+++ b/modules/shared/components/atoms/Tab/Tab.tsx
@@ -14,7 +14,7 @@ const Tab: FC<ITab.IProps> = (props): ReactElement => {
     changeValHandler,
     disabled,
     onlyLabel,
-    children,
+    content,
   } = props;
 
   const tabClasses: string = classNames(styles['tab-default'], {
@@ -42,7 +42,7 @@ const Tab: FC<ITab.IProps> = (props): ReactElement => {
           onlyLabel={onlyLabel}
         />
         {!onlyLabel && svg}
-        <span className={styles['tab-type']}>{children}</span>
+        <span className={styles['tab-type']}>{content}</span>
       </label>
     </div>
   );

--- a/modules/shared/components/atoms/Tab/__snapshots__/Tab.test.tsx.snap
+++ b/modules/shared/components/atoms/Tab/__snapshots__/Tab.test.tsx.snap
@@ -71,7 +71,7 @@ exports[`Tab should render tab with checked status 1`] = `
     <span
       className="tab-type"
     >
-      Mini survey
+      Image Poll
     </span>
   </label>
 </div>

--- a/modules/shared/components/molecules/CreatePostHeader/__snapshots__/CreatePostHeader.test.tsx.snap
+++ b/modules/shared/components/molecules/CreatePostHeader/__snapshots__/CreatePostHeader.test.tsx.snap
@@ -205,7 +205,7 @@ exports[`CreatePostHeader should render three tabs with filled avatar 1`] = `
             <span
               className="tab-type"
             >
-              Mini survey
+              Mini Survey
             </span>
           </label>
         </div>
@@ -360,7 +360,7 @@ exports[`CreatePostHeader should render three tabs with notFilled avatar 1`] = `
             <span
               className="tab-type"
             >
-              Mini survey
+              Mini Survey
             </span>
           </label>
         </div>

--- a/modules/shared/components/molecules/TabGroup/ITabGroup.d.ts
+++ b/modules/shared/components/molecules/TabGroup/ITabGroup.d.ts
@@ -4,6 +4,7 @@ import type { ITab } from '../../atoms/Tab/ITab';
 declare namespace ITabGroup {
   export interface IProps extends IData, ITab.IHandlers {
     checkedValue: string;
+    onlyLabel?: boolean;
   }
 
   export interface IData {

--- a/modules/shared/components/molecules/TabGroup/TabGroup.stories.tsx
+++ b/modules/shared/components/molecules/TabGroup/TabGroup.stories.tsx
@@ -21,4 +21,5 @@ const Template: Story<ITabGroup.IProps> = (args): ReactElement => (
 export const tabGroup = Template.bind({});
 tabGroup.args = {
   tabsData: tabGroupData(),
+  onlyLabel: false,
 };

--- a/modules/shared/components/molecules/TabGroup/TabGroup.tsx
+++ b/modules/shared/components/molecules/TabGroup/TabGroup.tsx
@@ -12,7 +12,7 @@ import type { ITabGroup } from './ITabGroup';
  * */
 
 const TabGroup: FC<ITabGroup.IProps> = (props): ReactElement => {
-  const { tabsData, checkedValue, changeValHandler } = props;
+  const { tabsData, checkedValue, changeValHandler, onlyLabel } = props;
 
   return (
     <div className="flex items-center">
@@ -24,6 +24,7 @@ const TabGroup: FC<ITabGroup.IProps> = (props): ReactElement => {
             value={tab.postType}
             changeValHandler={changeValHandler}
             checkedValue={checkedValue}
+            onlyLabel={onlyLabel}
           >
             {tab.value}
           </Tab>

--- a/modules/shared/components/molecules/TabGroup/TabGroup.tsx
+++ b/modules/shared/components/molecules/TabGroup/TabGroup.tsx
@@ -25,9 +25,8 @@ const TabGroup: FC<ITabGroup.IProps> = (props): ReactElement => {
             changeValHandler={changeValHandler}
             checkedValue={checkedValue}
             onlyLabel={onlyLabel}
-          >
-            {tab.value}
-          </Tab>
+            content={tab.value}
+          />
         </div>
       ))}
     </div>

--- a/modules/shared/components/molecules/TabGroup/TabGroup.tsx
+++ b/modules/shared/components/molecules/TabGroup/TabGroup.tsx
@@ -24,7 +24,9 @@ const TabGroup: FC<ITabGroup.IProps> = (props): ReactElement => {
             value={tab.postType}
             changeValHandler={changeValHandler}
             checkedValue={checkedValue}
-          />
+          >
+            {tab.value}
+          </Tab>
         </div>
       ))}
     </div>


### PR DESCRIPTION
closes #504
- add content prop to **Tab** comp to take any string 
- add onlyLabel prop to **TabGroup** comp to reuse the tabs in the new pages
- updated **Tab** & **TabGroup**  tests