### PR TITLE
Report post api

### DIFF
--- a/modules/shared/api/EStatusCode.ts
+++ b/modules/shared/api/EStatusCode.ts
@@ -4,6 +4,7 @@ export enum EStatusCode {
   Accepted = 202,
   BadRequest = 400,
   Unauthorized = 401,
+  Forbidden = 403,
   NotFound = 404,
   Conflict = 409,
   ManyRequests = 429,

--- a/modules/shared/api/reportPost/IReportPostApi.d.ts
+++ b/modules/shared/api/reportPost/IReportPostApi.d.ts
@@ -1,0 +1,19 @@
+declare namespace IReportPostApi {
+  export interface IReportPostRes {
+    resData: IReportPostErrorData | IReportPostSuccessData;
+  }
+
+  export interface IReportPostSuccessData {
+    message: string;
+  }
+  export interface IReportPostErrorData {
+    error: boolean;
+    message: string;
+    errorCode: number;
+  }
+  export interface IReportPostResErrorData {
+    response?: { data: { message: string; status_code: number } };
+  }
+}
+
+export { IReportPostApi };

--- a/modules/shared/api/reportPost/reportPost.test.ts
+++ b/modules/shared/api/reportPost/reportPost.test.ts
@@ -1,0 +1,78 @@
+import axios from 'axios';
+import { reportPost } from './reportPostApi';
+
+jest.mock('axios');
+
+const mockedAxios = axios as jest.Mocked<typeof axios>;
+
+describe('reportPost', () => {
+  it('should return success message when we pass valid post id and valid token', async () => {
+    mockedAxios.post.mockResolvedValue({
+      data: null,
+      status: 200,
+      statusText: 'ok',
+      headers: 'any',
+      config: {},
+    });
+
+    const { resData } = await reportPost('0', '00');
+
+    const expectedData = { message: 'Post has been reported successfully' };
+
+    expect(resData).toEqual(expectedData);
+  });
+
+  it("Should reject Network Error if there's not a response cames from the server", async () => {
+    mockedAxios.post.mockRejectedValue({ message: 'Network Error' });
+
+    try {
+      await reportPost('0', '00');
+    } catch (error: unknown) {
+      const expectedData = {
+        resData: { error: true, message: 'Network Error' },
+      };
+
+      expect(JSON.stringify(error)).toEqual(JSON.stringify(expectedData));
+    }
+  });
+
+  it('Should reject Error object with custom message if client did recognized the status code', async () => {
+    mockedAxios.post.mockRejectedValue(
+      Object.assign(new Error(), {
+        response: { data: { status_code: 401, message: 'unauthorized' } },
+      }),
+    );
+
+    try {
+      await reportPost('0', '00');
+    } catch (error: unknown) {
+      const expectedData = {
+        resData: {
+          error: true,
+          message: 'Please login first to interact with our app',
+          errorCode: 401,
+        },
+      };
+
+      expect(JSON.stringify(error)).toEqual(JSON.stringify(expectedData));
+    }
+  });
+
+  it('Should reject Error object and return same message if client did not recognized the status code', async () => {
+    mockedAxios.post.mockRejectedValue(
+      Object.assign(new Error(), {
+        response: { data: { status_code: 15, message: 'error message' } },
+      }),
+    );
+
+    try {
+      await reportPost('0', '00');
+    } catch (error: unknown) {
+      const expectedData = {
+        resData: { error: true, message: 'error message', errorCode: 15 },
+      };
+
+      expect(JSON.stringify(error)).toEqual(JSON.stringify(expectedData));
+    }
+  });
+});

--- a/modules/shared/api/reportPost/reportPostApi.ts
+++ b/modules/shared/api/reportPost/reportPostApi.ts
@@ -1,0 +1,39 @@
+import axios from 'axios';
+import type { IReportPostApi } from './IReportPostApi';
+import { errorMessage } from './reportPostHelpers';
+import { generateErrMsg } from '../../logic/generateErrMsg/generateErrMsg';
+
+export const reportPost = async (
+  postId: string,
+  token: string,
+): Promise<IReportPostApi.IReportPostRes> => {
+  try {
+    await axios.post(
+      `https://pickify-posts-be-dev.m3ntorship.net/api/reports`,
+      { report_type: 'post', post_id: postId },
+      { headers: { Authorization: `Bearer ${token}` } },
+    );
+
+    return { resData: { message: 'Post has been reported successfully' } };
+  } catch (err: unknown) {
+    const { response } = err as IReportPostApi.IReportPostResErrorData;
+    const { message: errMessage } = err as { message: string };
+
+    if (!response) {
+      throw Object.assign(new Error(), {
+        resData: { error: true, message: errMessage },
+      });
+    }
+
+    const { message, status_code } = response.data;
+    const generatedMessage = generateErrMsg(errorMessage, status_code, message);
+
+    throw Object.assign(new Error(), {
+      resData: {
+        error: true,
+        message: generatedMessage,
+        errorCode: status_code,
+      },
+    });
+  }
+};

--- a/modules/shared/api/reportPost/reportPostHelpers.ts
+++ b/modules/shared/api/reportPost/reportPostHelpers.ts
@@ -1,0 +1,10 @@
+import { EStatusCode } from '../EStatusCode';
+
+export const errorMessage: Record<number, string> = {
+  [EStatusCode.NotFound]: 'Post not found',
+  [EStatusCode.Unauthorized]: 'Please login first to interact with our app',
+  [EStatusCode.BadRequest]: 'Something went wrong',
+  [EStatusCode.Conflict]: "You've already reported this post",
+  [EStatusCode.ManyRequests]: 'You can not report more than 50 posts per day',
+  [EStatusCode.Forbidden]: 'You can not report your own post',
+};

--- a/modules/shared/components/molecules/PostViewHeader/IPostViewHeader.d.ts
+++ b/modules/shared/components/molecules/PostViewHeader/IPostViewHeader.d.ts
@@ -1,6 +1,7 @@
 declare namespace IPostViewHeader {
   export interface IProps {
     deletePostHandler: (postId: string) => void;
+    reportPostHandler: (postId: string) => void;
     userId: string;
     postId: string;
     profilePic?: string;

--- a/modules/shared/components/molecules/PostViewHeader/PostViewHeader.tsx
+++ b/modules/shared/components/molecules/PostViewHeader/PostViewHeader.tsx
@@ -31,6 +31,7 @@ const PostViewHeader: FC<IPostViewHeader.IProps> = ({
   userId,
   date,
   deletePostHandler,
+  reportPostHandler,
   postId,
   isHidden,
 }): ReactElement => {
@@ -40,6 +41,7 @@ const PostViewHeader: FC<IPostViewHeader.IProps> = ({
         deletePostHandler(postId);
         break;
       case 'report':
+        reportPostHandler(postId);
         break;
       case 'save':
         break;

--- a/modules/shared/components/organisms/SinglePostView/ISinglePostView.d.ts
+++ b/modules/shared/components/organisms/SinglePostView/ISinglePostView.d.ts
@@ -4,6 +4,7 @@ declare namespace IPost {
   export interface Props {
     post: IPostFeed.IPost;
     deletePostHandler: (postId: string) => void;
+    reportPostHandler: (postId: string) => void;
     addOneVoteHandler: (optionId: string, grouId: string) => void;
   }
 }

--- a/modules/shared/components/organisms/SinglePostView/SinglePostView.tsx
+++ b/modules/shared/components/organisms/SinglePostView/SinglePostView.tsx
@@ -41,6 +41,7 @@ const SinglePostView: FC<IPost.Props> = ({
   post,
   deletePostHandler,
   addOneVoteHandler,
+  reportPostHandler,
 }): ReactElement => {
   const postType = post.type.toLowerCase();
   let votedOptions: IPostFeed.IOptions[] = [];
@@ -76,6 +77,7 @@ const SinglePostView: FC<IPost.Props> = ({
             profilePic={user ? user.profile_pic : undefined}
             isHidden={post.is_hidden}
             deletePostHandler={deletePostHandler}
+            reportPostHandler={reportPostHandler}
           />
         </Box.Header>
         <Box.Body>


### PR DESCRIPTION
closes #367
- created `reportPostApi` function for reports endpoint
- declared return types for `reportPostApi`
- covered all `reportPostApi` test cases
- integrated  `reportPostApi` with home-page, user-profile-page and  get-one-post-page