### PR TITLE
Used totalPostsCount instead of postsCount

### DIFF
--- a/modules/ProfilePage/api/IGetUserData.d.ts
+++ b/modules/ProfilePage/api/IGetUserData.d.ts
@@ -8,6 +8,7 @@ declare namespace IGetUserData {
   export interface IUserSuccessData {
     posts: IPostFeed.IPost[];
     postsCount: number;
+    totalPostsCount: number;
     user: IPostFeed.IUser;
   }
 

--- a/modules/ProfilePage/pages/ProfilePage.tsx
+++ b/modules/ProfilePage/pages/ProfilePage.tsx
@@ -12,7 +12,12 @@ import Edit from '../../shared/components/icons/edit.svg';
 import Box from '../../shared/components/atoms/Box/Box';
 
 const ProfilePage: FC<{
-  data: { posts: IPostFeed.IPost[]; postsCount: number; user: IPostFeed.IUser };
+  data: {
+    posts: IPostFeed.IPost[];
+    postsCount: number;
+    totalPostsCount: number;
+    user: IPostFeed.IUser;
+  };
 }> = ({ data }): ReactElement => {
   const [checkedValue, setCheckedValue] = useState('posts');
   const onTabGroupChangeValueHandler = (
@@ -47,7 +52,7 @@ const ProfilePage: FC<{
                       </ImgWithInfo.Info.SubTitle>
                       <ImgWithInfo.Info.MoreInfo classes="mt-2">
                         <p className="font-normal text-sm text-dark-grey mr-4">
-                          Posts: {data.postsCount}
+                          Posts: {data.totalPostsCount}
                         </p>
                       </ImgWithInfo.Info.MoreInfo>
                     </>

--- a/pages/profile/[userid].tsx
+++ b/pages/profile/[userid].tsx
@@ -10,7 +10,12 @@ import { getUserData } from '@modules/ProfilePage/api/getUserData';
 import type { IGetUserData } from '@modules/ProfilePage/api/IGetUserData';
 
 const User: FC<{
-  data: { posts: IPostFeed.IPost[]; postsCount: number; user: IPostFeed.IUser };
+  data: {
+    posts: IPostFeed.IPost[];
+    postsCount: number;
+    totalPostsCount: number;
+    user: IPostFeed.IUser;
+  };
 }> = ({ data }): ReactElement => {
   return <ProfilePage data={data} />;
 };


### PR DESCRIPTION
In profile page we are supposed to display the total number of posts created by the user, `postsCount` is the property that represents the number of posts returned from the back end after the pagination and not the whole posts so we used `totalPostsCount` instead.